### PR TITLE
Make it possible to pass configuration file path to load_config

### DIFF
--- a/src/recall/config.py
+++ b/src/recall/config.py
@@ -17,8 +17,11 @@ class ConfigNotFoundError(ConfigError, FileNotFoundError):
         super().__init__(f"Configuration file not found at {path}")
 
 
-def load_config(config_path: Path = DEFAULT_CONFIG_PATH) -> dict[str, Any]:
+def load_config(config_path: Path | None = None) -> dict[str, Any]:
     """Load and parse the YAML configuration file."""
+    if not config_path:
+        config_path = DEFAULT_CONFIG_PATH
+
     if not config_path.exists():
         raise ConfigNotFoundError(config_path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,13 @@ def test_load_config_not_found():
         load_config(non_existent_path)
 
 
+@pytest.mark.usefixtures("fs")
+def test_load_config_default_not_found():
+    """Test that ConfigNotFoundError is raised for a non-existent file."""
+    with pytest.raises(ConfigNotFoundError):
+        load_config()
+
+
 def test_load_config_yaml_error(fs: FakeFilesystem):
     """Test that ConfigError is raised for a malformed YAML file."""
     config_path = "/fake/path/malformed.yaml"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,7 @@ def mock_valid_cli_args():
 def mock_parse_arguments():
     """Fixture to mock parse_arguments."""
     with patch("recall.main.parse_arguments") as mock:
-        mock.return_value = make_dt(0)
+        mock.return_value = make_dt(0), None
         yield mock
 
 
@@ -74,6 +74,7 @@ def test_parse_arguments_no_date(mock_arg_parser: MagicMock):
     """Test that the default date (today) is used when none is provided."""
     mock_args = MagicMock()
     mock_args.date = "2025-10-12"
+    mock_args.config = None
     mock_arg_parser.return_value.parse_args.return_value = mock_args
 
     with patch("recall.main.datetime") as mock_datetime:
@@ -81,7 +82,7 @@ def test_parse_arguments_no_date(mock_arg_parser: MagicMock):
         mock_datetime.strptime.return_value.replace.return_value = "fake_datetime"
 
         result = parse_arguments()
-        assert result == "fake_datetime"
+        assert result == ("fake_datetime", None)
         mock_datetime.strptime.assert_called_with("2025-10-12", "%Y-%m-%d")
 
 
@@ -401,7 +402,8 @@ async def test_main_interactive_mode(
 
     await main()
 
-    expected_date = mock_parse_arguments.return_value.strftime("%Y-%m-%d")
+    target_date, _ = mock_parse_arguments.return_value
+    expected_date = target_date.strftime("%Y-%m-%d")
     expected_text = f"🚀 Collecting activity for {expected_date}..."
     mock_yaspin.assert_called_once_with(
         text=expected_text,


### PR DESCRIPTION
## Make it possible to pass configuration file path to load_config

### Description

This PR addresses issue #3 by making it possible to specify a custom path for the main `config.yaml` file via a command-line argument. This provides more flexibility for users who may not use the standard `XDG_CONFIG_HOME` directory or wish to store their configuration in a different location.

### Key Changes

* **CLI Argument**: Added a **-c** / **--config** command-line argument to the `recall` command, accepting a `Path` object. This allows users to specify an alternative path to their configuration file.
* **Updated Main Logic**: The `main` function in `src/recall/main.py` has been updated to receive the optional config path from `parse_arguments` and pass it directly to `load_config`.
* **Updated Config Logic**: The `load_config` function in `src/recall/config.py` now accepts an optional `config_path` (`Path | None`) and falls back to `DEFAULT_CONFIG_PATH` if no argument is provided.
* **Test Updates**: The test suite in `tests/test_main.py` has been updated to account for the new tuple return signature of the `parse_arguments` function and to correctly mock the new argument parsing behavior.

### Usage Example

You can now run the tool with a custom configuration file like this:
```bash
recall -c /path/to/your/custom_config.yaml 2025-01-01
```

Fixes #3.